### PR TITLE
Add #[allow(clippy::unnecessary_cast)] in Specifier::from_bytes impl

### DIFF
--- a/impl/src/bitfield/expand.rs
+++ b/impl/src/bitfield/expand.rs
@@ -85,6 +85,7 @@ impl BitfieldStruct {
                 }
 
                 #[inline]
+                #[allow(clippy::unnecessary_cast)]
                 fn from_bytes(
                     bytes: Self::Bytes,
                 ) -> ::core::result::Result<Self::InOut, ::modular_bitfield::error::InvalidBitPattern<Self::Bytes>>


### PR DESCRIPTION
Fixes warning in 
```rust
#[bitfield]
#[derive(BitfieldSpecifier)]
pub struct Test {
    pub test: B8,
}
```